### PR TITLE
Fix choose_role() using wrong SAML provider when there are >1 role

### DIFF
--- a/Python-AWS/centrify/cenapp.py
+++ b/Python-AWS/centrify/cenapp.py
@@ -120,8 +120,8 @@ def choose_role(encoded_saml, appkey):
         selection = 1
         
     role = allroles[selection-1]
-    
-    principle = saml_provider [0]
+    principle = saml_provider[selection-1]
+
     print('You Chose : ', role)
     print('Your SAML Provider : ', principle)
         


### PR DESCRIPTION
Before this fix, the tool failed to assume an AWS role when there are multiple roles available.
For example:

```bash
Please choose the role you would like to assume -
[ 1 ]:  arn:aws:iam::111111111:role/ADFSUser
[ 2 ]:  arn:aws:iam::222222222:role/ADFSUser
Please select : 2

You Chose :  arn:aws:iam::222222222:role/ADFS-Admin
Your SAML Provider :  arn:aws:iam::111111111:saml-provider/ADFS    #  WRONG PROVIDER

Access Denied. Please check..
An error occurred (ValidationError) when calling the AssumeRoleWithSAML operation:
Principal exists outside the account of the Role being assumed
```
