### PR TITLE
Fix "No AWS Applications to select for the user"

### DIFF
--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -96,7 +96,9 @@ def client_main():
     for j in range (0, length):
         try:
             appinfo = {}
-            if (("AWS" in apps[j]["TemplateName"] or "Amazon" in apps[j]["TemplateName"]) and apps[j]["WebAppType"] != 'UsernamePassword'):
+            awsName = "AWS" in apps[j]["Name"] or "Amazon" in apps[j]["Name"]
+            awsTemplate = "AWS" in apps[j]["TemplateName"] or "Amazon" in apps[j]["TemplateName"]
+            if ((awsName or awsTemplate) and apps[j]["WebAppType"] != 'UsernamePassword'):
                 appinfo = apps[j]
                 logging.info(appinfo)
                 awsapps.append(appinfo)


### PR DESCRIPTION
In our setup (which I think is standard) the AWS application exists with `Name=AWS` instead of `TemplateName=AWS`