### PR TITLE
Usability improvements

### DIFF
--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -63,10 +63,10 @@ def select_app(awsapps):
              
 def client_main():
     parser = argparse.ArgumentParser(description="Enter Centrify Credentials and choose AWS Role to create AWS Profile. Use this AWS Profile to run AWS commands.")
-    parser.add_argument("-tenant", "-t", help="Enter tenant url or name e.g. cloud.centrify.com or cloud", default="cloud")
-    parser.add_argument("-region", "-r", help="Enter AWS region. Default is us-west-2", default="us-west-2")
-#    parser.add_argument("-cert", "-c", help="Enter Cert file name. Default is cacerts_<tenant>.pem", default="cacerts")
-    parser.add_argument("-debug", "-d", help="This will make debug on", action="store_true")
+    parser.add_argument("--tenant", "-t", help="Enter tenant url or name e.g. cloud.centrify.com or cloud", default="cloud")
+    parser.add_argument("--region", "-r", help="Enter AWS region. Default is us-west-2", default="us-west-2")
+#    parser.add_argument("--cert", "-c", help="Enter Cert file name. Default is cacerts_<tenant>.pem", default="cacerts")
+    parser.add_argument("--debug", "-d", help="This will make debug on", action="store_true")
     args = parser.parse_args()
     
     set_logging()

--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -147,8 +147,9 @@ def client_main():
 try:
     client_main()
 except SystemExit as se:
-    print("Program Exited due to error or wrong input..")
-    logging.exception("Program Exited due to error or wrong input..")
+    if se.code != 0:
+        print("Program Exited due to error or wrong input..")
+        logging.exception("Program Exited due to error or wrong input..")
 except:
     print("Program Exited due to some error..")
     logging.exception("Program Exited..")

--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -72,12 +72,11 @@ def client_main():
 
     set_logging()
 
+    # FIXME: assume no if the file doesn't exist
     try:
         proxy_obj = readconfig.read_config()
-    except:
-        logging.info("proxy.properties file not found. Please make sure the files are at home dir of the script.")
-        print("proxy.properties file not found. Please make sure the files are at home dir of the script.")
-        sys.exit()
+    except Exception:
+        raise RuntimeError("proxy.properties file not found. Please make sure the files are at home dir of the script.")
     proxy = {}
     if proxy_obj.is_proxy() == 'yes':
         proxy={ 'http':proxy_obj.get_http(), 'https':proxy_obj.get_https(), 'username':proxy_obj.get_user(), 'password':proxy_obj.get_password() }
@@ -107,7 +106,7 @@ def client_main():
     logging.info("AWSapps : " + str(awsapps))
 
     if (len(awsapps) == 0):
-        print("No AWS Applications to select for the user " + user)
+        print("No AWS Applications to select for the user " + user, file=sys.stderr)
         return
 
     pattern = re.compile("[^0-9.]")
@@ -148,11 +147,12 @@ try:
     client_main()
 except SystemExit as se:
     if se.code != 0:
-        print("Program Exited due to error or wrong input..")
+        print("Program Exited due to error or wrong input...", file=sys.stderr)
         logging.exception("Program Exited due to error or wrong input..")
 except:
-    print("Program Exited due to some error..")
-    logging.exception("Program Exited..")
+    logging.exception("Unhandled Exception")
+    # FIXME: configure logging to display to the console as well
+    print("Program Exited due to unhandled exception...", file=sys.stderr)
     exc_type, exc_value, exc_traceback = sys.exc_info()
     traceback.print_exception(exc_type, exc_value, exc_traceback)
 finally:

--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -23,6 +23,7 @@ import sys
 import argparse
 from config import environment
 import traceback
+import os
 
 def get_environment(args):
     tenant = args.tenant
@@ -64,7 +65,7 @@ def select_app(awsapps):
 def client_main():
     parser = argparse.ArgumentParser(description="Enter Centrify Credentials and choose AWS Role to create AWS Profile. Use this AWS Profile to run AWS commands.")
     parser.add_argument("--tenant", "-t", help="Enter tenant url or name e.g. cloud.centrify.com or cloud", default="cloud")
-    parser.add_argument("--region", "-r", help="Enter AWS region. Default is us-west-2", default="us-west-2")
+    parser.add_argument("--region", "-r", help="Enter AWS region. Default is %(default)s", default=os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
     parser.add_argument("--cert", "-c", help="Custom certificate file name. Default is the standard browser root.", default=None)
     parser.add_argument("--debug", "-d", help="This will make debug on", action="store_true")
     args = parser.parse_args()

--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -30,11 +30,11 @@ def get_environment(args):
         tenant = tenant + ".centrify.com"
     name = tenant.split(".")[0]
     tenant = "https://" + tenant
-    cert = "cacerts_" + name + ".pem"
+    cert = args.cert
     debug = args.debug
     env = environment.Environment(name, tenant, cert, debug)
     return env
-    
+
 
 
 def login_instance(proxy, environment):
@@ -48,7 +48,7 @@ def set_logging():
     logging.basicConfig(handlers=[logging.FileHandler('centrify-python-aws.log', 'w', 'utf-8')], level=logging.INFO, format='%(asctime)s %(filename)s %(funcName)s %(lineno)d %(message)s')
     logging.info('Starting App..')
     print("Logfile - centrify-python-aws.log")
-    
+
 
 def select_app(awsapps):
     print("Select the aws app to login. Type 'quit' or 'q' to exit")
@@ -60,17 +60,17 @@ def select_app(awsapps):
         return "1"
     return input("Enter Number : ")
 
-             
+
 def client_main():
     parser = argparse.ArgumentParser(description="Enter Centrify Credentials and choose AWS Role to create AWS Profile. Use this AWS Profile to run AWS commands.")
     parser.add_argument("--tenant", "-t", help="Enter tenant url or name e.g. cloud.centrify.com or cloud", default="cloud")
     parser.add_argument("--region", "-r", help="Enter AWS region. Default is us-west-2", default="us-west-2")
-#    parser.add_argument("--cert", "-c", help="Enter Cert file name. Default is cacerts_<tenant>.pem", default="cacerts")
+    parser.add_argument("--cert", "-c", help="Custom certificate file name. Default is the standard browser root.", default=None)
     parser.add_argument("--debug", "-d", help="This will make debug on", action="store_true")
     args = parser.parse_args()
-    
+
     set_logging()
-    
+
     try:
         proxy_obj = readconfig.read_config()
     except:
@@ -82,9 +82,9 @@ def client_main():
         proxy={ 'http':proxy_obj.get_http(), 'https':proxy_obj.get_https(), 'username':proxy_obj.get_user(), 'password':proxy_obj.get_password() }
     environment = get_environment(args)
     session, user = login_instance(proxy, environment)
-    
+
     region = args.region
-    
+
     response = uprest.get_applications(user, session, environment, proxy)
     result = response["Result"]
     logging.info("Result " + str(result))
@@ -104,11 +104,11 @@ def client_main():
             continue
 
     logging.info("AWSapps : " + str(awsapps))
-    
+
     if (len(awsapps) == 0):
         print("No AWS Applications to select for the user " + user)
         return
-    
+
     pattern = re.compile("[^0-9.]")
     count = 1
     profilecount = [0] * len(awsapps)
@@ -121,7 +121,7 @@ def client_main():
             break
         if (int(number) - 1 >= len(awsapps)):
             continue
-        
+
         appkey = awsapps[int(number)-1]['AppKey']
         display_name = awsapps[int(number)-1]['DisplayName']
         print("Calling app with key : " + appkey)
@@ -143,7 +143,7 @@ def client_main():
     logging.info("Done")
     logging.shutdown()
 
-try:    
+try:
     client_main()
 except SystemExit as se:
     print("Program Exited due to error or wrong input..")
@@ -155,4 +155,3 @@ except:
     traceback.print_exception(exc_type, exc_value, exc_traceback)
 finally:
     logging.shutdown()
-

--- a/Python-AWS/CentrifyAWSCLI.py
+++ b/Python-AWS/CentrifyAWSCLI.py
@@ -68,6 +68,9 @@ def client_main():
     parser.add_argument("--region", "-r", help="Enter AWS region. Default is %(default)s", default=os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
     parser.add_argument("--cert", "-c", help="Custom certificate file name. Default is the standard browser root.", default=None)
     parser.add_argument("--debug", "-d", help="This will make debug on", action="store_true")
+    parser.add_argument("--use-app-name-for-profile", help="Use the application name for the profile's name",
+                        action="store_true",
+                        default=os.environ.get("CENTRIFY_USE_APP_NAME_FOR_PROFILE", "") == "true")
     args = parser.parse_args()
 
     set_logging()
@@ -131,7 +134,8 @@ def client_main():
             if (_quit == 'q'):
                 break;
             count = profilecount [int(number)-1]
-            assumed = assumerolesaml.assume_role_with_saml(awsinputs.role, awsinputs.provider, awsinputs.saml, count, display_name, region)
+            assumed = assumerolesaml.assume_role_with_saml(awsinputs.role, awsinputs.provider, awsinputs.saml, count, display_name, region,
+                                                           use_app_name_for_profile=args.use_app_name_for_profile)
             if (assumed):
                 profilecount [int(number)-1] = count + 1
             if (_quit == 'one_role_quit'):

--- a/Python-AWS/Pipfile
+++ b/Python-AWS/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+boto3 = "*"
+colorama = "*"
+
+[requires]
+python_version = "3.8"

--- a/Python-AWS/Pipfile.lock
+++ b/Python-AWS/Pipfile.lock
@@ -1,0 +1,117 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "386bf74846fb571230505c0e85ebf50018ecf1fdf8213aa539c96819dbb60929"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "boto3": {
+            "hashes": [
+                "sha256:3b00b93d9548ebc0777f54cbd77c11e2721f7bb873ffb371cf4fa66d06750de7",
+                "sha256:3d3973502f96faaa534faec083ce4cd51a969f613d740be9e34cb7e42238f59c"
+            ],
+            "index": "pypi",
+            "version": "==1.12.14"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:37e713b86bc833587e002610d0b2b5c5c88438617d68189d1b541e20726a43d4",
+                "sha256:4f889842519f54d007e285637c625a0645ffbe6aaa291b62ba510f3a25948f77"
+            ],
+            "version": "==1.15.14"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "index": "pypi",
+            "version": "==0.4.3"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
+                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
+            ],
+            "version": "==0.9.5"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "index": "pypi",
+            "version": "==2.23.0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.25.8"
+        }
+    },
+    "develop": {}
+}

--- a/Python-AWS/aws/assumerolesaml.py
+++ b/Python-AWS/aws/assumerolesaml.py
@@ -48,23 +48,17 @@ def write_cred(cred, count, display_name, region, role):
     print('aws s3 ls --profile ' + section)
     print('-' * 80)
 
-    
+
 
 def assume_role_with_saml(role, principle, saml, count, display_name, region):
     stsclient = boto3.client('sts')
+
     try:
         cred = stsclient.assume_role_with_saml(RoleArn=role, PrincipalArn=principle, SAMLAssertion=saml)
     except ClientError as e:
-        print("Access Denied. Please check.. " + str(e))
-        logging.info(str(e))
+        logging.error("Access denied: %s", e, exc_info=True)
+        print("Access Denied: %s" % e, file=sys.stderr)
         return False
-    '''
-    print(cred)
-    print(cred['Credentials'])
-    print(cred['Credentials']['SecretAccessKey'])
-    print(cred['Credentials']['AccessKeyId'])
-    print(cred['Credentials']['SessionToken'])
-    '''
+
     write_cred(cred, count, display_name, region, role)
     return True
-    

--- a/Python-AWS/aws/assumerolesaml.py
+++ b/Python-AWS/aws/assumerolesaml.py
@@ -14,23 +14,22 @@
 
 import boto3
 from botocore.exceptions import ClientError
-from os.path import expanduser
+from os.path import expanduser, join
 import configparser
 import sys
 import logging
 
 def write_cred(cred, count, display_name, region, role):
     home = expanduser("~")
-    print('home = ' + home)
-    cred_file = home + "/.aws/credentials"
+    cred_file = join(home, ".aws", "credentials")
     config = configparser.RawConfigParser()
     config.read(cred_file)
     print("Display Name : " + display_name)
     rolesplit = role.split('/')
     profile_name = rolesplit[1] + '_profile'
-#    profile_name = display_name.replace(" ","-")
-#    section = 'saml' + str(count)
-    section = profile_name #+ '_' + str(count)
+
+    section = profile_name
+
     if not config.has_section(section):
         config.add_section(section)
     config.set(section, 'output', 'json')

--- a/Python-AWS/centrify/cenapp.py
+++ b/Python-AWS/centrify/cenapp.py
@@ -66,10 +66,8 @@ def call_app(session, appkey, version, environment, proxy):
     logging.info(html_response)
     encoded_saml = html_response.get_saml()
     if (encoded_saml == ''):
-        logging.info('Did not receive SAML response. Please check if you have chosen Saml App')
-        print('Did not receive SAML response. Please check if you have chosen Saml App')
-        print('Exiting..')
-        sys.exit()
+        logging.error('Did not receive SAML response. Please check if you have chosen Saml App')
+        raise RuntimeError('Did not receive SAML response. Please check if you have chosen Saml App')
     return encoded_saml
 #    return choose_role(encoded_saml, appkey)
 
@@ -112,7 +110,7 @@ def choose_role(encoded_saml, appkey):
         except ValueError:
             return 'q', None
         if (selection > len(allroles)):
-            print('You have selected a wrong role..')
+            print('You have selected a wrong role..', file=sys.stderr)
             sys.exit(0)
     else:
         print('1: ' + allroles[0])


### PR DESCRIPTION
This makes some basic improvements for the user experience:

* Uses the standard certificate store by default, avoiding the need to manage files unless you need to use a certificate which isn't in the standard browser trust chain used by Python requests
* Better handling of error messages
* Don't treat usage of `--help` as an error
* Use the same region configuration as the AWS CLI and SDKs to avoid requiring double-entry
* Allow using the application name as the profile name for enterprise environments where you have common roles across projects